### PR TITLE
minor bugfix in README and pisco_combine

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Other Required Python Packages:
 
 ### Running the Astrometry pipeline
 ```python
-python pisco_pipeline/pisco_combine.py data/ Field026
+python pisco_pipeline/pisco_combine.py /path/to/data/ Field024
 ```
-where *data/* is the directory wherer the PISCO raw data Field024_A_82.fits and Field024_A_83.fits are located, and Field024 is the prefix for all the files that you want to combine together. Run python script outside *pisco_pipeline/* directory next to *data/* directory is located.
+where */path/to/data/* is the directory where the PISCO raw data Field024_A_82.fits and Field024_A_83.fits are located, and Field024 is the prefix for all the files that you want to combine together. Run python script outside *pisco_pipeline/* directory next to *data/* directory is located.
 
 The main outputs (4 fits images based on 4 different bands) will be located in *final/* directory.
 

--- a/pisco_combine.py
+++ b/pisco_combine.py
@@ -330,7 +330,7 @@ if __name__ == "__main__":
     if not os.path.exists('final'):
         os.makedirs('final')
 
-    fields=[name.split('/')[1].split('.')[0] for name in list_file_name(dir,fieldname)]
+    fields=[name.split('/')[-1].split('.')[0] for name in list_file_name(dir,fieldname)]
     for field in fields:
         for index in [1,3,5,7]:
             ch1, bias1, domeflat1, img1=reduce_data(dir,index,field)


### PR DESCRIPTION
`pisco_combine.py` now accepts any path fed to it as its first command
line argument (formerly made stronger assumptions about directory
structure).

Minor typo corrections in README.